### PR TITLE
Get compression buffer size from zstd

### DIFF
--- a/src/object_container_file_encoding/writer/compression.rs
+++ b/src/object_container_file_encoding/writer/compression.rs
@@ -230,7 +230,8 @@ impl CompressionCodecState {
 			#[cfg(feature = "zstandard")]
 			Kind::Zstandard { compressor, level } => {
 				self.output_vec.clear();
-				self.output_vec.reserve(32 * 1024);
+				self.output_vec
+					.reserve(zstd::zstd_safe::compress_bound(input.len()));
 
 				let compressor = match compressor {
 					None => {


### PR DESCRIPTION
The hard-coded buffer size is sometimes too small. Get the worst-case buffer size
from zstd instead.
