### PR TITLE
avoid using `std` feature in rust_decimal

### DIFF
--- a/serde_avro_fast/Cargo.toml
+++ b/serde_avro_fast/Cargo.toml
@@ -22,7 +22,7 @@
 	integer-encoding = { default-features = false, version = "4" }
 	num-traits = "0.2"
 	rand = "0.8"
-	rust_decimal = { version = "1", default-features = false, features = ["std", "serde-with-str"] }
+	rust_decimal = { version = "1", default-features = false, features = ["serde-with-str"] }
 	serde = "1"
 	serde-transcode = "1"
 	serde_derive = "1"


### PR DESCRIPTION
This reduces the number of dependencies, and `cargo check` and `cargo test` still run fine.

It came up because I was setting up `cargo vet` in my code, and was surprised to see `rkyv` in our list of dependencies.  It'll be nice to have fewer dependencies to audit, and `rkyv` would be a particularly hefty crate to audit.

Of course, it's also nice for compile times to avoid depending on so many crates.