### PR TITLE
Bump apache-avro dev-dependency from 0.17 to 0.21 and migrate xz2 to liblzma

### DIFF
--- a/serde_avro_fast/Cargo.toml
+++ b/serde_avro_fast/Cargo.toml
@@ -12,7 +12,7 @@
 	default = ["deflate"]
 	deflate = ["flate2"]
 	snappy = ["snap", "crc32fast"]
-	xz = ["xz2"]
+	xz = ["liblzma"]
 	zstandard = ["zstd"]
 
 [dependencies]
@@ -30,12 +30,12 @@
 	serde_serializer_quick_unsupported = "1"
 	snap = { version = "1", optional = true }
 	thiserror = "2"
-	xz2 = { version = "0.1", optional = true }
+	liblzma = { version = "0.4", optional = true }
 	zstd = { version = "0.13", optional = true }
 
 [dev-dependencies]
 	anyhow = "1"
-	apache-avro = { version = "0.17", features = ["bzip", "snappy", "xz", "zstandard"] }
+	apache-avro = { version = "0.21", features = ["bzip", "snappy", "xz", "zstandard"] }
 	criterion = "0.8"
 	lazy_static = "1"
 	paste = "1"

--- a/serde_avro_fast/src/object_container_file_encoding/reader/decompression.rs
+++ b/serde_avro_fast/src/object_container_file_encoding/reader/decompression.rs
@@ -113,7 +113,7 @@ impl CompressionCodec {
 			CompressionCodec::Xz => DecompressionState::BufReader {
 				deserializer_state: de::DeserializerState::with_config(
 					de::read::ReaderRead::new(std::io::BufReader::new(
-						DecompressionReaderForBufReader::Xz(xz2::bufread::XzDecoder::new(
+						DecompressionReaderForBufReader::Xz(liblzma::bufread::XzDecoder::new(
 							de::read::take::Take::take(reader, block_size)?,
 						)),
 					)),
@@ -179,7 +179,7 @@ pub(super) enum DecompressionReaderForBufReader<R: std::io::BufRead> {
 	#[cfg(feature = "bzip2")]
 	Bzip2(bzip2::bufread::BzDecoder<R>),
 	#[cfg(feature = "xz")]
-	Xz(xz2::bufread::XzDecoder<R>),
+	Xz(liblzma::bufread::XzDecoder<R>),
 	#[cfg(feature = "zstandard")]
 	Zstandard(zstd::stream::read::Decoder<'static, R>),
 }

--- a/serde_avro_fast/src/object_container_file_encoding/writer/compression.rs
+++ b/serde_avro_fast/src/object_container_file_encoding/writer/compression.rs
@@ -199,9 +199,9 @@ impl CompressionCodecState {
 			}
 			#[cfg(feature = "xz")]
 			Kind::Xz { len, level } => {
-				let mut compress = xz2::stream::Stream::new_easy_encoder(
+				let mut compress = liblzma::stream::Stream::new_easy_encoder(
 					level.instantiate_nb(6),
-					xz2::stream::Check::Crc64,
+					liblzma::stream::Check::Crc64,
 				)
 				.map_err(|err| error("Xz", &err))?;
 				if self.output_vec.is_empty() {
@@ -214,25 +214,25 @@ impl CompressionCodecState {
 						.process(
 							input,
 							&mut self.output_vec[compress.total_out() as usize..],
-							xz2::stream::Action::Finish,
+							liblzma::stream::Action::Finish,
 						)
 						.map_err(|deflate_error| error("Xz", &deflate_error))?;
 					let written = compress.total_in() as usize - before_in;
 					match status {
-						xz2::stream::Status::MemNeeded => {
+						liblzma::stream::Status::MemNeeded => {
 							// There may be more to write.
 							// That may be true even if the input is empty, because bzip2
 							// may have buffered some input.
 							input = &input[written..];
 							self.output_vec.resize(self.output_vec.len() * 2, 0);
 						}
-						xz2::stream::Status::Ok | xz2::stream::Status::GetCheck => {
+						liblzma::stream::Status::Ok | liblzma::stream::Status::GetCheck => {
 							return Err(error(
 								"Xz",
 								&format_args!("got unexpected status from xz2: {status:?}"),
 							));
 						}
-						xz2::stream::Status::StreamEnd => {
+						liblzma::stream::Status::StreamEnd => {
 							assert_eq!(input.len(), written);
 							*len = compress.total_out() as usize;
 							break;


### PR DESCRIPTION
`apache-avro` 0.21 switched its `xz` compression backend from `lzma-sys` (via `xz2`) to `liblzma`. Cargo's links resolver only allows a single package in the dependency graph to claim links = "lzma", so pulling in `apache-avro` 0.21 alongside our existing `xz2` dependency caused resolution to fail:

  package `liblzma-sys` links to the native library `lzma`, but it
  conflicts with a previous package which links to `lzma` as well:
  package `lzma-sys v0.1.20`

Resolve the conflict by migrating serde_avro_fast's own xz feature from `xz2` (0.1) to `liblzma` (0.4). `liblzma` is a maintained successor to `xz2` with an API-compatible surface, so the change is mechanical: the feature flag now pulls in liblzma, and the writer/reader simply swap the `xz2::` paths for `liblzma::` paths. No behavioural changes.

Verified with `cargo nextest run --all-features` (156 tests pass).