### PR TITLE
Remove zstandard decompression workaround, requiring zstd 0.14

### DIFF
--- a/serde_avro_fast/Cargo.toml
+++ b/serde_avro_fast/Cargo.toml
@@ -31,7 +31,7 @@
 	snap = { version = "1", optional = true }
 	thiserror = "2"
 	xz2 = { version = "0.1", optional = true }
-	zstd = { version = "0.13", optional = true }
+	zstd = { version = "0.14", optional = true }
 
 [dev-dependencies]
 	anyhow = "1"

--- a/serde_avro_fast/src/object_container_file_encoding/reader/decompression.rs
+++ b/serde_avro_fast/src/object_container_file_encoding/reader/decompression.rs
@@ -217,28 +217,16 @@ impl<'s, R: de::read::take::Take> DecompressionState<'s, R> {
 						DecompressionReaderForBufReader::Xz(reader) => reader.into_inner(),
 						#[cfg(feature = "zstandard")]
 						DecompressionReaderForBufReader::Zstandard(mut reader) => {
-							// With zstandard, we need to manually drive the reader to the end by
-							// asking to deserialize the rest of the data. If the serialized avro is
-							// correct, this should not yield anything, but if we don't, it won't
-							// read the last bytes of the compressed data, resulting in an error
-							// when checking that there's no data left in the block.
-							// https://github.com/gyscos/zstd-rs/issues/255
-							let mut drive_reader_to_end_buf = [0];
-							let read =
-								std::io::Read::read(&mut reader, &mut drive_reader_to_end_buf)
-									.map_err(|e| {
-										de::DeError::custom_io(
-											"Zstandard error when driving decompressor to end",
-											e,
-										)
-									})?;
-							if read != 0 {
-								return Err(de::DeError::new(
-									"Zstandard decompression error: There's \
-									decompressed data left in the \
-									block after reading the whole avro block out of it",
-								));
-							}
+							// `finish` reads the last bytes of the compressed frame, which we need,
+							// otherwise we would error when checking that there's no data left in
+							// the block. It ignores any IO error encountered while doing so
+							// however, so we call `finish_frame` first to surface those.
+							reader.finish_frame().map_err(|e| {
+								de::DeError::custom_io(
+									"Zstandard error when reading the end of the frame",
+									e,
+								)
+							})?;
 							reader.finish()
 						}
 					})

--- a/serde_avro_fast/tests/object_container_file_encoding.rs
+++ b/serde_avro_fast/tests/object_container_file_encoding.rs
@@ -290,6 +290,55 @@ fn test_writer_zstandard() {
 	);
 }
 
+/// Once the whole avro block has been deserialized, the zstd decoder may not
+/// have read the end of the compressed frame yet, because it can hand out the
+/// last of the decompressed data before reading the frame epilogue. We still
+/// have to consume it, otherwise we'd consider that there's data left in the
+/// block. That only happens if the block decompresses to more than the buffer
+/// we decompress into, so use blocks that are large enough for that.
+/// https://github.com/gyscos/zstd-rs/issues/255
+#[cfg(feature = "zstandard")]
+#[test]
+fn test_writer_zstandard_block_larger_than_decompression_buffer() {
+	#[derive(Deserialize, Serialize, Debug, PartialEq, Eq)]
+	struct OwnedSchemaRecord {
+		a: i64,
+		b: String,
+	}
+
+	let input: Vec<OwnedSchemaRecord> = (0..1000)
+		.map(|i| OwnedSchemaRecord {
+			a: i,
+			b: format!("{i:0>100}"),
+		})
+		.collect();
+
+	let schema: Schema = SCHEMA.parse().unwrap();
+
+	for approx_block_size in [8 * 1024, 64 * 1024, 1024 * 1024] {
+		let mut serializer_config = SerializerConfig::new(&schema);
+		let mut writer = WriterBuilder::new(&mut serializer_config)
+			.compression(Compression::Zstandard {
+				level: CompressionLevel::default(),
+			})
+			.approx_block_size(approx_block_size)
+			.build(Vec::new())
+			.unwrap();
+		writer.serialize_all(input.iter()).unwrap();
+		let serialized = writer.into_inner().unwrap();
+
+		let mut reader = Reader::from_slice(&serialized).unwrap();
+		let from_slice: Vec<OwnedSchemaRecord> =
+			reader.deserialize().collect::<Result<_, _>>().unwrap();
+		assert_eq!(input, from_slice);
+
+		let mut reader = Reader::from_reader(&serialized[..]).unwrap();
+		let from_reader: Vec<OwnedSchemaRecord> =
+			reader.deserialize().collect::<Result<_, _>>().unwrap();
+		assert_eq!(input, from_reader);
+	}
+}
+
 #[test]
 fn test_reader_invalid_header() {
 	//let schema: Schema = SCHEMA.parse().unwrap();


### PR DESCRIPTION
[gyscos/zstd-rs#255](https://github.com/gyscos/zstd-rs/issues/255) is [fixed in zstd 0.14](https://github.com/gyscos/zstd-rs/issues/255#issuecomment-5545267099): `Decoder::finish()` now consumes the rest of the frame before handing the reader back.

So the workaround goes away: instead of manually driving the decoder to the end with a one-byte read, we now just call `finish_frame()` (to surface the IO errors that `finish()` swallows) and `finish()`.

## Dependency

`zstd 0.13 -> 0.14`. `zstd` isn't exposed in this crate's public API, so this isn't a breaking change for users. Note that `apache-avro` (dev-dependency) still requires `zstd ^0.13`; both end up in the lockfile but share a single `zstd-sys 2.1.0`, so there's no `links` conflict and `cargo test --all-features` builds fine.